### PR TITLE
Only execute validators related to OAS 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0] - 2025-01-02
+[0.5.0]: https://github.com/mhassan1/openapi-semantic-validator/compare/v0.4.0...v0.5.0
+
+- Only execute validators related to OAS 3
+
 ## [0.4.0] - 2024-04-24
 [0.4.0]: https://github.com/mhassan1/openapi-semantic-validator/compare/v0.3.0...v0.4.0
 

--- a/src/validateOpenapiSemantics.ts
+++ b/src/validateOpenapiSemantics.ts
@@ -83,7 +83,14 @@ export const validateOpenapiSemantics = async (
   const semanticErrors = []
 
   for (const [validatorName, validator] of Object.entries(validators)) {
-    if (!validatorName.startsWith('validate')) continue
+    if (
+      // only include validators that are related to oas3
+      // this matches the logic in the `validators` function in `selectors.js`
+      !validatorName.startsWith('validate2And3') &&
+      !validatorName.startsWith('validateOAS3')
+    ) {
+      continue
+    }
     semanticErrors.push(...(await validator()(system)))
   }
 

--- a/test/fixtures/spec1.json
+++ b/test/fixtures/spec1.json
@@ -10,6 +10,11 @@
       "url": "https://spec1.com"
     }
   ],
+  "security": [
+    {
+      "my-oauth": ["read"]
+    }
+  ],
   "paths": {
     "/path1/{parameter1}": {
       "get": {
@@ -38,6 +43,19 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      }
+    },
+    "securitySchemes": {
+      "my-oauth": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://spec1.com/token",
+            "scopes": {
+              "read": "read"
+            }
+          }
         }
       }
     }

--- a/test/fixtures/spec2.json
+++ b/test/fixtures/spec2.json
@@ -24,7 +24,7 @@
             "schema": {
               "type": "string"
             },
-            "required": false
+            "required": true
           }
         ],
         "responses": {
@@ -42,6 +42,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Parameter2"
+          },
+          {
+            "$ref": "#/components/parameters/Authorization"
           }
         ],
         "responses": {
@@ -58,7 +61,16 @@
         "name": "parameter2",
         "in": "path",
         "description": "Parameter 2",
-        "required": false,
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Authorization": {
+        "name": "authorization",
+        "in": "header",
+        "description": "Authorization",
+        "required": true,
         "schema": {
           "type": "string"
         }

--- a/test/test.ts
+++ b/test/test.ts
@@ -35,22 +35,16 @@ test('validate openapi semantics (failure)', async () => {
         level: 'error'
       },
       {
-        level: 'error',
+        level: 'warning',
         message:
-          "Path parameters must have 'required: true'. You can always create another path/operation without this parameter to get the same behaviour.",
-        path: ['paths', '/path1', 'post', 'parameters', '0']
+          'Header parameters named "Authorization" are ignored. Use the `securitySchemes` and `security` sections instead to define authorization.',
+        path: ['paths', '/path2/{parameter2}', 'get', 'parameters', '1', 'name']
       },
       {
-        level: 'error',
+        level: 'warning',
         message:
-          "Path parameters must have 'required: true'. You can always create another path/operation without this parameter to get the same behaviour.",
-        path: ['paths', '/path2/{parameter2}', 'get', 'parameters', '0']
-      },
-      {
-        level: 'error',
-        message:
-          "Path parameters must have 'required: true'. You can always create another path/operation without this parameter to get the same behaviour.",
-        path: ['components', 'parameters', 'Parameter2']
+          'Header parameters named "Authorization" are ignored. Use the `securitySchemes` and `security` sections instead to define authorization.',
+        path: ['components', 'parameters', 'Authorization', 'name']
       }
     ])
   }


### PR DESCRIPTION
This PR updates the list of validators to include only ones related to OAS 3; currently, we are running Swagger validators against OAS 3 specifications, which is incorrect.