### PR TITLE
Move to `swagger-editor` v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.0] - 2025-07-01
+[0.6.0]: https://github.com/mhassan1/openapi-semantic-validator/compare/v0.5.0...v0.6.0
+
+- Move to `swagger-editor` v4
+
 ## [0.5.0] - 2025-01-02
 [0.5.0]: https://github.com/mhassan1/openapi-semantic-validator/compare/v0.4.0...v0.5.0
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "opencollective/minimist": "^1.2.8"
   },
   "_bundled": {
-    "swagger-editor": "3.18.2"
+    "swagger-editor": "4.14.6"
   },
   "jest": {
     "preset": "ts-jest",

--- a/scripts/clone-swagger-editor.js
+++ b/scripts/clone-swagger-editor.js
@@ -4,7 +4,7 @@ const { cpSync, writeFileSync } = require('fs')
 const { tempDir, buildDir } = execEnv
 
 // this must always match the version of `_bundled.swagger-editor` in `package.json`
-const version = '3.18.2'
+const version = '4.14.6'
 
 execFileSync('git', [
   'clone', 'https://github.com/swagger-api/swagger-editor.git',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5304,9 +5304,9 @@ __metadata:
   linkType: hard
 
 "swagger-editor-git@exec:./scripts/clone-swagger-editor.js::locator=openapi-semantic-validator%40workspace%3A.":
-  version: 3.18.2
-  resolution: "swagger-editor-git@exec:./scripts/clone-swagger-editor.js#./scripts/clone-swagger-editor.js::hash=3dc40e&locator=openapi-semantic-validator%40workspace%3A."
-  checksum: 10c0/b408b516c4c7828abf226380430d73ade05fc5ee315e90be1e3d8f449f98075f6700fbeb3838ef916ef8bfcb991905970c402e537314e748478b7f8bcc79ff75
+  version: 4.14.6
+  resolution: "swagger-editor-git@exec:./scripts/clone-swagger-editor.js#./scripts/clone-swagger-editor.js::hash=84c840&locator=openapi-semantic-validator%40workspace%3A."
+  checksum: 10c0/f21fde314e76dc9dc1c157614dd1f946683fad8347c6465dbd96923648bfbbd1e7f17a43dd199cf568a913bae17fb0294f8477dbe19bfe78a47be99c48e523a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR bumps the bundled version of `swagger-editor` from `3.18.2` to `4.14.6`.